### PR TITLE
Terminal version as default instalation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,17 +14,17 @@ LazyData: TRUE
 SystemRequirements: C++11, fftw3 (>= 3.3.5)
 Depends:
     R (>= 3.6),
-    methods,
-    gWidgets2 (>= 1.0),
-    RGtk2 (>= 2.20.25),
-    cairoDevice (>= 2.22),
-    gWidgets2RGtk2 (>= 1.0)
+    methods
 Imports:
     raster (>= 2.4),
     digest (>= 0.6.9),
     Rcpp (>= 0.12.2)
 Suggests:
     ggplot2 (>= 3.0.0),
-    gridExtra (>= 2.3)
+    gridExtra (>= 2.3),
+    gWidgets2 (>= 1.0),	
+    RGtk2 (>= 2.20.25),	
+    cairoDevice (>= 2.22),	
+    gWidgets2RGtk2 (>= 1.0)
 LinkingTo: Rcpp
 RoxygenNote: 7.2.0

--- a/R/MSIWindow.R
+++ b/R/MSIWindow.R
@@ -33,6 +33,12 @@
 #' @export
 OpenMSI<-function( lockExecution = F )
 {
+  
+  if(!(requireNamespace("RGtk2",quietly = T)))
+  {
+    stop("ERROR: this function requires to install the RGtk2 package. Check the guides to install it properly in the Github \"prafols/rMSI2\" \n")
+  }
+  
   #Load data using GUI
   MSI_obj<-LoadTwoMsImages()
 

--- a/R/Process.R
+++ b/R/Process.R
@@ -44,6 +44,11 @@ ProcessImages <- function(proc_params,
     stop("ERROR: proc_params argument must be an object of class \"ProcParams\". Use the rMSI2::ProcessingParameters() function to create a valid proc_params\n")
   }
   
+  if((proc_params$preprocessing$massCalibration) && !(requireNamespace("RGtk2",quietly = T)))
+  {
+    stop("ERROR: mass calibration requires to install the RGtk2 package. Check the guides to install it properly in the Github \"prafols/rMSI2\" \n")
+  }
+  
   if(class(data_description) != "DataInfo")
   {
     stop("ERROR: data_description argument must be an object of class \"DataInfo\". Use the rMSI2::ImzMLDataDescription() function to create a valid data_description.\n")

--- a/R/Process.R
+++ b/R/Process.R
@@ -604,6 +604,12 @@ FormatPeakMatrix <- function (cPeakMatrix, posMat, numPixels, names, uuid, posMo
 #'
 ProcessWizard <- function( deleteRamdisk = T, overwriteRamdisk = F, calibrationSpan = 0.75, store_binsize_txt_file = F )
 {
+  
+   if(!(requireNamespace("RGtk2",quietly = T)))
+  {
+    stop("ERROR: this function requires to install the RGtk2 package. Check the guides to install it properly in the Github \"prafols/rMSI2\" \n")
+  }
+  
   #Get processing params using a GUI
   wizardResult <- ImportWizardGui()
   

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -1,10 +1,10 @@
 ### Installation
 
-*rMSI2* provides a quite complex data model together with a graphical user interface (GUI), consequently rMSI2 depends on some other R packages that must be also installed. RGtk2 is one of these packages and is known to be problematic to install on Windows systems since it is not maintained anymore. Thus, we provide an installation guides for each operating system (MAC OSX is not available yet).
+*rMSI2* provides a quite complex data model together with an optional graphical user interface (GUI), consequently rMSI2 depends on some other R packages that must be also installed. To use the GUI, RGtk2 is required and is known to be problematic to install on Windows systems since it is not maintained anymore. Thus, we provide an installation guides for each operating system (**MAC OSX is not available**).
 
-We are very aware of the issues related to the GUI installation for rMSI2 and the downsides of it and therefore, we are working to develop a new GUI model to overcome this issue. But, in the meanwhile, we provide this guide to facilitate a successful installation of rMSI2. 
+We are very aware of the issues related to the optinal GUI installation for rMSI2 and the downsides of it and therefore, we are working to develop a new GUI model to overcome this issue. But, in the meanwhile, we provide this guide to facilitate a successful installation of rMSI2 with the GUI operative. 
 
-Before installing rMSI2 ensure you have the RGtk2 related dependencies installed properly by following the guide below corresponding to your operating system.
+Follow the instructions below corresponding to your operating system to install the dependencies needed for the GUI .
 
 * ##### Instructions for Windows users
 
@@ -27,7 +27,7 @@ RGtk2 is not available anymore as a binary package easy to install from CRAN to 
 * ##### Instructions for Linux users
 Gtk2 is a graphical library that comes pre-installed in almost any Linux distribution, and therefore it is really straight forward to get rMSI2 working on a Linux machine. Due to the changes introduced in R's graphical engine since version 4.2, RGtk2 is not able to work with the latest R releases. So, ensure you have installed R version 4.1. Next, you'll have to download RGtk2, gWidgets2RGtk2 and cairoDevice packages source and install them manually.
 
-* ##### Common installation of rMSI2 for all platforms
+* ##### Common installation of rMSI2 for all platforms (with or without GUI)
 The simplest way to install rMSI2 and keep it updated is using devtools package. Install devtools from CRAN into your R session:
 ```R
 >  install.packages("devtools")


### PR DESCRIPTION
Stablish the terminal-only version as the default installation. 
If a user tries to use methods with GUI an error message will appear recommending the installation of all suggested packages. 
So far, seems to work properly both on Windows and Debian systems.
